### PR TITLE
docs: format readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,101 +1,120 @@
 # Ivory 🐘
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/tristanfisher/ivory.svg)](https://pkg.go.dev/github.com/tristanfisher/ivory)
-[![Go Report Card](https://goreportcard.com/badge/github.com/tristanfisher/ivory)](https://goreportcard.com/report/github.com/tristanfisher/ivory)
+[![Go
+Reference](https://pkg.go.dev/badge/github.com/tristanfisher/ivory.svg)](https://pkg.go.dev/github.com/tristanfisher/ivory)
+[![Go Report
+Card](https://goreportcard.com/badge/github.com/tristanfisher/ivory)](https://goreportcard.com/report/github.com/tristanfisher/ivory)
 
-## overview
+## Overview
 
-Ivory makes it easy for you to create and manage PostgreSQL databases via a Go program.
+Ivory makes it easy for you to create and manage PostgreSQL databases via a Go
+program.
 
-This is particularly useful during tests or any other time that you only want a pg database with a lifecycle that is managed programmatically.
+This is particularly useful during tests or any other time that you only want a
+pg database with a lifecycle that is managed programmatically.
 
-## usage
+## Usage
 
-When not told to create a database or run SQL, ivory will simply try to connect to a PostgreSQL database, return database handles, and an function for dropping an existing database and closing DB handles.
+When not told to create a database or run SQL, ivory will simply try to connect
+to a PostgreSQL database, return database handles, and an function for dropping
+an existing database and closing DB handles.
 
-However, the primary goal of this library is to make it easy to bootstrap and cleanup databases.
+However, the primary goal of this library is to make it easy to bootstrap and
+cleanup databases.
 
-The following is likely all you need to know in order to make use of this library:
+The following is likely all you need to know in order to make use of this
+library:
 
-- If a database name is provided in the options, a random database name is not generated.
-Otherwise, a collision-resistant database name is generated.
+- If a database name is provided in the options, a random database name is not
+generated. Otherwise, a collision-resistant database name is generated.
 - If told to create a database, Ivory will oblige and bind 2 connections:
-1. Server-scoped (connection without database in connection string -- required to drop a database instance)
-2. Database-scoped (connection with database in connection string)
-
-- A slice of strings may be provided for Ivory to be treated as migrations.  These may include any valid SQL, including transactions.
-- A "tear down function" that will drop the created (or specified) database and close database handles is returned.  Calling this is optional.  Ivory does not implicitly drop databases or close connections.
+  1. Server-scoped (connection without database in connection string -- required
+     to drop a database instance)
+  2. Database-scoped (connection with database in connection string)
+- A slice of strings may be provided for Ivory to be treated as migrations.
+  These may include any valid SQL, including transactions.
+- A "tear down function" that will drop the created (or specified) database and
+  close database handles is returned.  Calling this is optional.  Ivory does not
+  implicitly drop databases or close connections.
 
 As an example:
 
-	dbOptions := &ivory.DatabaseOptions{
-		Host:     "localhost",
-		Port:     5555,
-		SslMode:  "disable",
-		User:     "postgres",
-		Password: "rootUserSeriousPassword1",
-	}
-	// we discard two db handles here, one to the instance, one scoped to the database in the instance
-	// teardown() closes database handles and cleans up the created database
-	_, _, dbName, teardown, err := ivory.New(
-		context.TODO(),
-		dbOptions,
-		[]string{"CREATE TABLE grocery_list (item char(25))"},
-		true,
-		"my_app")
-	defer teardown()
-	if err != nil {
-		fmt.Println("error creating: ", err)
-		return
-	}
-	fmt.Printf("created: %s", dbName)
+```go
+dbOptions := &ivory.DatabaseOptions{
+  Host:     "localhost",
+  Port:     5555,
+  SslMode:  "disable",
+  User:     "postgres",
+  Password: "rootUserSeriousPassword1",
+}
+// we discard two db handles here, one to the instance, one scoped to the
+// database in the instance teardown() closes database handles and cleans up
+// the created database
+_, _, dbName, teardown, err := ivory.New(
+  context.TODO(),
+  dbOptions,
+  []string{"CREATE TABLE grocery_list (item char(25))"},
+  true,
+  "my_app")
+defer teardown()
+if err != nil {
+  fmt.Println("error creating: ", err)
+  return
+}
+fmt.Printf("created: %s", dbName)
+```
 
 After the deferred function is called, the database is dropped.
 
 As an example of how to create many databases:
 
-    // set aside database-context connections, say if we want to use them as normal *sql.DB handles
-	availableDBs := make(map[string]*sql.DB, 0)
-	for i := 0; i < 10; i++ {
-		// important: must be inside loop as dbOptions are updated in place!
-		opts := &ivory.DatabaseOptions{
-			Host:     "localhost",
-			Port:     5555,
-			SslMode:  "disable",
-			User:     "postgres",
-			Password: "rootUserSeriousPassword1",
-		}
+```go
+// set aside database-context connections, say if we want to use them as normal
+// *sql.DB handles
+availableDBs := make(map[string]*sql.DB, 0)
+for i := 0; i < 10; i++ {
+  // important: must be inside loop as dbOptions are updated in place!
+  opts := &ivory.DatabaseOptions{
+    Host:     "localhost",
+    Port:     5555,
+    SslMode:  "disable",
+    User:     "postgres",
+    Password: "rootUserSeriousPassword1",
+  }
 
-		// we discard two db handles here, one to the instance, one scoped to the database in the instance
-		// teardown() closes database handles and cleans up the created database
-		_, dbScopedConn, dbName, teardown, err := ivory.New(ctx, opts, fixtureTable, true, "")
-		if err != nil {
-			fmt.Println("=> failed to create a database: ", err)
-			continue
-		}
-		defer teardown()
-		availableDBs[dbName] = dbScopedConn
-	}
-	databasesCreated := ""
-	for k, _ := range availableDBs {
-		databasesCreated += fmt.Sprintf("%s ", k)
-	}
-	fmt.Printf("created: %s", databasesCreated)
-    // created: _disp_pg_1664125384_q57qcq8qid6a7k7d _disp_pg_1664125384_1yj7i14v7iqauzln _disp_pg_1664125385_galb4ijb...
+  // we discard two db handles here, one to the instance, one scoped to the
+  // database in the instance teardown() closes database handles and cleans up
+  // the created database
+  _, dbScopedConn, dbName, teardown, err := ivory.New(ctx, opts, fixtureTable, true, "")
+  if err != nil {
+    fmt.Println("=> failed to create a database: ", err)
+    continue
+  }
+  defer teardown()
+  availableDBs[dbName] = dbScopedConn
+}
+databasesCreated := ""
+for k, _ := range availableDBs {
+  databasesCreated += fmt.Sprintf("%s ", k)
+}
+fmt.Printf("created: %s", databasesCreated)
+  // created: _disp_pg_1664125384_q57qcq8qid6a7k7d _disp_pg_1664125384_1yj7i14v7iqauzln _disp_pg_1664125385_galb4ijb...
+```
 
+That's it!  No need to act as a database janitor or deal with a slowly growing
+PostgreSQLinstance.
 
-That's it!  No need to act as a database janitor or deal with a slowly growing PostgreSQLinstance.
+That said, if your code panics or the context is cancelled before the deferred
+functions can run, `FindLikelyAbandonedDBs()` and `DropDB()` are available to
+you for finding and dropping databases, respectively.
 
-That said, if your code panics or the context is cancelled before the deferred functions can run,
-`FindLikelyAbandonedDBs()` and `DropDB()` are available to you for finding and dropping databases, respectively.
-
-
-
-
-## development / contribution
+## Development / Contribution
 
 Pull requests or GitHub issues are welcomed.
 
-If you are creating a pull request, please include tests as well as a description of the problem being solved.
+If you are creating a pull request, please include tests as well as a
+description of the problem being solved.
 
-If you are opening a GitHub issue, please include the error message and verify that your database is listening to connections (`connection refused` likely means the wrong database host or port is being specified).
+If you are opening a GitHub issue, please include the error message and verify
+that your database is listening to connections (`connection refused` likely
+means the wrong database host or port is being specified).

--- a/README.md
+++ b/README.md
@@ -7,35 +7,29 @@ Card](https://goreportcard.com/badge/github.com/tristanfisher/ivory)](https://go
 
 ## Overview
 
-Ivory makes it easy for you to create and manage PostgreSQL databases via a Go
-program.
+Ivory makes it easy for you to create and manage PostgreSQL databases via a Go program.
 
-This is particularly useful during tests or any other time that you only want a
-pg database with a lifecycle that is managed programmatically.
+This is particularly useful during tests or any other time that you only want a pg database with a lifecycle that is
+managed programmatically.
 
 ## Usage
 
-When not told to create a database or run SQL, ivory will simply try to connect
-to a PostgreSQL database, return database handles, and an function for dropping
-an existing database and closing DB handles.
+When not told to create a database or run SQL, ivory will simply try to connect to a PostgreSQL database, return
+database handles, and an function for dropping an existing database and closing DB handles.
 
-However, the primary goal of this library is to make it easy to bootstrap and
-cleanup databases.
+However, the primary goal of this library is to make it easy to bootstrap and cleanup databases.
 
-The following is likely all you need to know in order to make use of this
-library:
+The following is likely all you need to know in order to make use of this library:
 
-- If a database name is provided in the options, a random database name is not
-generated. Otherwise, a collision-resistant database name is generated.
+- If a database name is provided in the options, a random database name is not generated. Otherwise, a
+collision-resistant database name is generated.
 - If told to create a database, Ivory will oblige and bind 2 connections:
-  1. Server-scoped (connection without database in connection string -- required
-     to drop a database instance)
+  1. Server-scoped (connection without database in connection string -- required to drop a database instance)
   2. Database-scoped (connection with database in connection string)
-- A slice of strings may be provided for Ivory to be treated as migrations.
-  These may include any valid SQL, including transactions.
-- A "tear down function" that will drop the created (or specified) database and
-  close database handles is returned.  Calling this is optional.  Ivory does not
-  implicitly drop databases or close connections.
+- A slice of strings may be provided for Ivory to be treated as migrations. These may include any valid SQL, including
+  transactions.
+- A "tear down function" that will drop the created (or specified) database and close database handles is returned.
+  Calling this is optional.  Ivory does not implicitly drop databases or close connections.
 
 As an example:
 
@@ -47,9 +41,8 @@ dbOptions := &ivory.DatabaseOptions{
   User:     "postgres",
   Password: "rootUserSeriousPassword1",
 }
-// we discard two db handles here, one to the instance, one scoped to the
-// database in the instance teardown() closes database handles and cleans up
-// the created database
+// we discard two db handles here, one to the instance, one scoped to the database in the instance teardown() closes
+// database handles and cleans up the created database
 _, _, dbName, teardown, err := ivory.New(
   context.TODO(),
   dbOptions,
@@ -69,8 +62,7 @@ After the deferred function is called, the database is dropped.
 As an example of how to create many databases:
 
 ```go
-// set aside database-context connections, say if we want to use them as normal
-// *sql.DB handles
+// set aside database-context connections, say if we want to use them as normal *sql.DB handles
 availableDBs := make(map[string]*sql.DB, 0)
 for i := 0; i < 10; i++ {
   // important: must be inside loop as dbOptions are updated in place!
@@ -82,9 +74,8 @@ for i := 0; i < 10; i++ {
     Password: "rootUserSeriousPassword1",
   }
 
-  // we discard two db handles here, one to the instance, one scoped to the
-  // database in the instance teardown() closes database handles and cleans up
-  // the created database
+  // we discard two db handles here, one to the instance, one scoped to the database in the instance teardown() closes
+  // database handles and cleans up the created database
   _, dbScopedConn, dbName, teardown, err := ivory.New(ctx, opts, fixtureTable, true, "")
   if err != nil {
     fmt.Println("=> failed to create a database: ", err)
@@ -101,20 +92,16 @@ fmt.Printf("created: %s", databasesCreated)
   // created: _disp_pg_1664125384_q57qcq8qid6a7k7d _disp_pg_1664125384_1yj7i14v7iqauzln _disp_pg_1664125385_galb4ijb...
 ```
 
-That's it!  No need to act as a database janitor or deal with a slowly growing
-PostgreSQLinstance.
+That's it!  No need to act as a database janitor or deal with a slowly growing PostgreSQLinstance.
 
-That said, if your code panics or the context is cancelled before the deferred
-functions can run, `FindLikelyAbandonedDBs()` and `DropDB()` are available to
-you for finding and dropping databases, respectively.
+That said, if your code panics or the context is cancelled before the deferred functions can run,
+`FindLikelyAbandonedDBs()` and `DropDB()` are available to you for finding and dropping databases, respectively.
 
 ## Development / Contribution
 
 Pull requests or GitHub issues are welcomed.
 
-If you are creating a pull request, please include tests as well as a
-description of the problem being solved.
+If you are creating a pull request, please include tests as well as a description of the problem being solved.
 
-If you are opening a GitHub issue, please include the error message and verify
-that your database is listening to connections (`connection refused` likely
-means the wrong database host or port is being specified).
+If you are opening a GitHub issue, please include the error message and verify that your database is listening to
+connections (`connection refused` likely means the wrong database host or port is being specified).


### PR DESCRIPTION
Hi, I have formatted the README.md 

- use fenced code blocks for syntax highlighting
- capitalize headings
- wrap text around 80 columns (can only be seen in the source, markdown doesn't care about a single line breaks)
- fix markdown-lint errors

Please let me know if that's to your liking and, if so, if I should open an issue for this, so I can link the PR to it.