### PR TITLE
chore: add github action to run test suit

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,38 @@
+name: test
+
+on:
+  workflow_dispatch: null
+  push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+
+    services:
+      postgresql:
+        image: postgres:14.1-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: rootUserSeriousPassword1
+          POSTGRES_DB: ivoryPgExisting
+        ports:
+          - 127.0.0.1:5555:5432
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.20"
+
+      - name: Run Test Suit
+        run: go test ./...

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 Reference](https://pkg.go.dev/badge/github.com/tristanfisher/ivory.svg)](https://pkg.go.dev/github.com/tristanfisher/ivory)
 [![Go Report
 Card](https://goreportcard.com/badge/github.com/tristanfisher/ivory)](https://goreportcard.com/report/github.com/tristanfisher/ivory)
+[![test](https://github.com/tristanfisher/ivory/actions/workflows/test.yaml/badge.svg)](https://github.com/bluebrown/ivory/actions/workflows/test.yaml)
 
 ## Overview
 


### PR DESCRIPTION
I have added a GitHub action to run the tests. This can be used to protect the main and releases branches on pull requests.

Due to the way GitHub actions work, you may need to do some "hacks" to have that pipeline run 1 time, before it is selectable via branch protection.
The way I did that was settings the `on` condition to `push` (and nothing else). I guess one could make a dummy branch and push to that just to get it working. 
Once that ran one time, the actual `on` conditions can be specified. For example, using the ones in this PR. 

```yaml
on:
  push: 
```

There is probably a better way.
