### PR TITLE
Add ssl cert options

### DIFF
--- a/main.go
+++ b/main.go
@@ -188,6 +188,9 @@ type DatabaseOptions struct {
 	User                  string `dsnFormat:"user='%s'"`
 	Password              string `dsnFormat:"password='%s'"`
 	SslMode               string `dsnFormat:"sslmode=%s"`
+	SslCert               string `dsnFormat:"sslcert='%s'"`
+	SslKey                string `dsnFormat:"sslkey='%s'"`
+	SslRootCert           string `dsnFormat:"sslrootcert='%s'"`
 	ConnectTimeoutSeconds int    `dsnFormat:"connect_timeout=%d"`
 	MaxOpenConns          int
 	MaxIdleConns          int
@@ -297,6 +300,28 @@ func (do *DatabaseOptions) DSN() (string, error) {
 			return "", err
 		}
 		dsnPortions = append(dsnPortions, fmt.Sprintf(partFmt, do.SslMode))
+	}
+
+	if len(do.SslCert) > 0 {
+		partFmt, err := do.GetDSNPart("SslCert")
+		if err != nil {
+			return "", err
+		}
+		dsnPortions = append(dsnPortions, fmt.Sprintf(partFmt, do.SslCert))
+	}
+	if len(do.SslKey) > 0 {
+		partFmt, err := do.GetDSNPart("SslKey")
+		if err != nil {
+			return "", err
+		}
+		dsnPortions = append(dsnPortions, fmt.Sprintf(partFmt, do.SslKey))
+	}
+	if len(do.SslRootCert) > 0 {
+		partFmt, err := do.GetDSNPart("SslRootCert")
+		if err != nil {
+			return "", err
+		}
+		dsnPortions = append(dsnPortions, fmt.Sprintf(partFmt, do.SslRootCert))
 	}
 
 	if do.ConnectTimeoutSeconds > 0 {

--- a/main_test.go
+++ b/main_test.go
@@ -76,6 +76,9 @@ func TestDatabaseOptions_DSN(t *testing.T) {
 		User                  string
 		Password              string
 		SslMode               string
+		SslCert               string
+		SslKey                string
+		SslRootcert           string
 		ConnectTimeoutSeconds int
 		MaxOpenConns          int
 		MaxIdleConns          int
@@ -141,10 +144,13 @@ func TestDatabaseOptions_DSN(t *testing.T) {
 				Schema:                "exampleSchema",
 				User:                  "user",
 				Password:              "password",
-				SslMode:               "disable",
+				SslMode:               "verify-full",
+				SslCert:               "./cert.pem",
+				SslKey:                "./key.pem",
+				SslRootcert:           "./rootcert.pem",
 				ConnectTimeoutSeconds: 10,
 			},
-			want: "host='localhost' port=1024 dbname='exampleDB' search_path='exampleSchema' user='user' password='password' sslmode=disable connect_timeout=10",
+			want: "host='localhost' port=1024 dbname='exampleDB' search_path='exampleSchema' user='user' password='password' sslmode=verify-full sslcert='./cert.pem' sslkey='./key.pem' sslrootcert='./rootcert.pem' connect_timeout=10",
 		},
 	}
 	for _, tt := range tests {
@@ -157,6 +163,9 @@ func TestDatabaseOptions_DSN(t *testing.T) {
 				User:                  tt.fields.User,
 				Password:              tt.fields.Password,
 				SslMode:               tt.fields.SslMode,
+				SslCert:               tt.fields.SslCert,
+				SslKey:                tt.fields.SslKey,
+				SslRootCert:           tt.fields.SslRootcert,
 				ConnectTimeoutSeconds: tt.fields.ConnectTimeoutSeconds,
 				MaxOpenConns:          tt.fields.MaxOpenConns,
 				MaxIdleConns:          tt.fields.MaxIdleConns,

--- a/main_test.go
+++ b/main_test.go
@@ -79,6 +79,7 @@ func TestDatabaseOptions_DSN(t *testing.T) {
 		SslCert               string
 		SslKey                string
 		SslRootcert           string
+		SslCertMode           string
 		ConnectTimeoutSeconds int
 		MaxOpenConns          int
 		MaxIdleConns          int
@@ -148,9 +149,10 @@ func TestDatabaseOptions_DSN(t *testing.T) {
 				SslCert:               "./cert.pem",
 				SslKey:                "./key.pem",
 				SslRootcert:           "./rootcert.pem",
+				SslCertMode:           "require",
 				ConnectTimeoutSeconds: 10,
 			},
-			want: "host='localhost' port=1024 dbname='exampleDB' search_path='exampleSchema' user='user' password='password' sslmode=verify-full sslcert='./cert.pem' sslkey='./key.pem' sslrootcert='./rootcert.pem' connect_timeout=10",
+			want: "host='localhost' port=1024 dbname='exampleDB' search_path='exampleSchema' user='user' password='password' sslmode=verify-full sslcert='./cert.pem' sslkey='./key.pem' sslrootcert='./rootcert.pem' sslcertmode=require connect_timeout=10",
 		},
 	}
 	for _, tt := range tests {
@@ -166,6 +168,7 @@ func TestDatabaseOptions_DSN(t *testing.T) {
 				SslCert:               tt.fields.SslCert,
 				SslKey:                tt.fields.SslKey,
 				SslRootCert:           tt.fields.SslRootcert,
+				SslCertMode:           tt.fields.SslCertMode,
 				ConnectTimeoutSeconds: tt.fields.ConnectTimeoutSeconds,
 				MaxOpenConns:          tt.fields.MaxOpenConns,
 				MaxIdleConns:          tt.fields.MaxIdleConns,


### PR DESCRIPTION
This change adds the following ssl/certificate options for connections:
- [`sslcert`](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLCERT)
- [`sslkey`](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLKEY)
- [`sslcertmode`](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLCERTMODE)
- [`sslrootcert`](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLROOTCERT)