### PR TITLE
Updates, documentation fixes, nil fix on Connect + abandoned functions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @tristanfisher

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  pull_request:
+    types:
+      # opened = new request
+      - opened
+      # reopened = closed PR is re-opened
+      - reopened
+      # synchronize = commits on active PR
+      - synchronize
+
+jobs:
+  lint-vet-test:
+    runs-on: ubuntu-latest
+
+    services:
+      ivory:
+        image: postgres:18-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: rootUserSeriousPassword1
+          POSTGRES_DB: ivoryPgExisting
+        ports:
+          - 5555:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache: true
+
+      - name: Run Go Vet
+        run: go vet ./...
+
+      - name: Run Staticcheck
+        run: |
+          go install honnef.co/go/tools/cmd/staticcheck@latest
+          $(go env GOPATH)/bin/staticcheck ./...
+
+      # with static analysis of changes done, confirm tests still pass
+      - name: Download Dependencies
+        run: go mod download
+
+      - name: Run Tests
+        env:
+          DATABASE_URL: postgres://postgres:rootUserSeriousPassword1@localhost:5555/ivoryPgExisting?sslmode=disable
+        run: go test ./...

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,11 @@ jobs:
           go-version: '1.23'
           cache: true
 
+      - name: Verify go mod is tidy
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum
+
       - name: Run go vet
         run: go vet ./...
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
           go-version: '1.23'
           cache: true
 
-      - name: Run Go Vet
+      - name: Run go vet
         run: go vet ./...
 
       - name: Run Staticcheck
@@ -48,10 +48,10 @@ jobs:
           $(go env GOPATH)/bin/staticcheck ./...
 
       # with static analysis of changes done, confirm tests still pass
-      - name: Download Dependencies
+      - name: Download dependencies
         run: go mod download
 
-      - name: Run Tests
+      - name: Run tests
         env:
           DATABASE_URL: postgres://postgres:rootUserSeriousPassword1@localhost:5555/ivoryPgExisting?sslmode=disable
         run: go test ./...

--- a/README.md
+++ b/README.md
@@ -14,24 +14,54 @@ managed programmatically.
 
 ## Usage
 
-When not told to create a database or run SQL, ivory will simply try to connect to a PostgreSQL database, return
-database handles, and an function for dropping an existing database and closing DB handles.
+### Connection handling
 
-However, the primary goal of this library is to make it easy to bootstrap and cleanup databases.
+When not told to create a database or run SQL, Ivory will simply try to connect to a PostgreSQL database, return
+database handles, and a function for dropping an existing database and closing DB handles.
+
+In this case, Ivory provides convenience and code clarity by providing a struct for connection instantiation instead of using string interpolation.
+
+e.g.
+
+Ivory:
+
+```go
+connOpts := &DatabaseOptions{
+    Host:     "localhost",
+    Port:     5555,
+    Database: "flannel",
+    SslMode:  "disable",
+    User:     "postgres",
+    Password: "rootUserSeriousPassword1",
+    SslMode:  "verify-full"
+}
+```
+
+versus string interpolation:
+
+```go
+connOpts := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
+		"localhost", 5555, "flannel", "rootUserSeriousPassword1", "flannel", "verify-full")
+```
+
+### Bootstrapping and Cleanup
+
+A goal of this library is to make it easy to bootstrap and cleanup databases.
 
 The following is likely all you need to know in order to make use of this library:
 
-- If a database name is provided in the options, a random database name is not generated. Otherwise, a
-collision-resistant database name is generated.
+- If a database name is provided in the options, it is used.  If no database name is provided in the options, a collision-resistant database name is generated.
 - If told to create a database, Ivory will oblige and bind 2 connections:
   1. Server-scoped (connection without database in connection string -- required to drop a database instance)
   2. Database-scoped (connection with database in connection string)
 - A slice of strings may be provided for Ivory to be treated as migrations. These may include any valid SQL, including
   transactions.
 - A "tear down function" that will drop the created (or specified) database and close database handles is returned.
-  Calling this is optional.  Ivory does not implicitly drop databases or close connections.
+  Calling this is optional.  Ivory does **not** implicitly drop databases or close connections.
 
-As an example:
+#### Examples
+
+Creating a single database with DDL:
 
 ```go
 dbOptions := &ivory.DatabaseOptions{

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   ivory:
     build:
       context: .
-    image: "postgres:14.1-alpine"
+    image: "postgres:18-alpine"
     environment:
       # POSTGRES_USER, POSTGRES_PASSWORD is the setup for the superuser
       POSTGRES_USER: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   ivory:
     build:

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/tristanfisher/ivory/v2
 
-go 1.20
+go 1.23
 
-require github.com/lib/pq v1.10.9
+require github.com/lib/pq v1.12.3

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lib/pq v1.12.3 h1:tTWxr2YLKwIvK90ZXEw8GP7UFHtcbTtty8zsI+YjrfQ=
+github.com/lib/pq v1.12.3/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
-github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.12.3 h1:tTWxr2YLKwIvK90ZXEw8GP7UFHtcbTtty8zsI+YjrfQ=
 github.com/lib/pq v1.12.3/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=

--- a/main.go
+++ b/main.go
@@ -412,7 +412,7 @@ func generateDbName(customIdPortion string) string {
 	// byte array of size 4*randSuffixLen
 	const charChoices = "abcdefghijklmnopqrstuvwxyz0123456789"
 	const charChoiceLen = len(charChoices)
-	
+
 	asciiSlice := make([]byte, randSuffixLen)
 	for i := range asciiSlice {
 		asciiSlice[i] = charChoices[rand.Intn(charChoiceLen)]

--- a/main.go
+++ b/main.go
@@ -412,11 +412,7 @@ func generateDbName(customIdPortion string) string {
 	// byte array of size 4*randSuffixLen
 	const charChoices = "abcdefghijklmnopqrstuvwxyz0123456789"
 	const charChoiceLen = len(charChoices)
-
-	// a little gross to re-seed each call, but so would be doing this even if not required in New()
-	// this is not expected to be needed to be crypto-secure
-	rand.Seed(time.Now().UnixNano())
-
+	
 	asciiSlice := make([]byte, randSuffixLen)
 	for i := range asciiSlice {
 		asciiSlice[i] = charChoices[rand.Intn(charChoiceLen)]

--- a/main.go
+++ b/main.go
@@ -93,6 +93,14 @@ func New(ctx context.Context, opts *DatabaseOptions, sqlText []string, createDat
 	userOptsDatabaseName := opts.Database
 	opts.Database = ""
 	dbHandleNoBoundDB, err := Connect(ctx, opts)
+
+	// previous versions of ivory returned dbHandleNoBoundDB.Close, even if Connect() erred
+	// noOpFn is returned so the expected Close() err can be called without nil checking.
+	noOpFn := func() error { return nil }
+	if dbHandleNoBoundDB == nil {
+		return nil, nil, opts.Database, noOpFn, err
+	}
+
 	if err != nil {
 		return nil, nil, opts.Database, dbHandleNoBoundDB.Close, err
 	}
@@ -469,6 +477,7 @@ func FindLikelyAbandonedDBs(ctx context.Context, dbHandle *sql.DB, prefix string
 	if err != nil {
 		return []string{}, err
 	}
+	defer rows.Close()
 	results := make([]string, 0)
 	for rows.Next() {
 		var r string

--- a/main.go
+++ b/main.go
@@ -94,15 +94,15 @@ func New(ctx context.Context, opts *DatabaseOptions, sqlText []string, createDat
 	opts.Database = ""
 	dbHandleNoBoundDB, err := Connect(ctx, opts)
 
-	// previous versions of ivory returned dbHandleNoBoundDB.Close, even if Connect() erred
-	// noOpFn is returned so the expected Close() err can be called without nil checking.
-	noOpFn := func() error { return nil }
-	if dbHandleNoBoundDB == nil {
-		return nil, nil, opts.Database, noOpFn, err
-	}
-
 	if err != nil {
-		return nil, nil, opts.Database, dbHandleNoBoundDB.Close, err
+		// previous versions of ivory returned dbHandleNoBoundDB.Close, even if Connect() erred
+		// a no-op function is returned so the expected Close() err can be called without nil checking.
+		closeFn := func() error { return nil }
+		if dbHandleNoBoundDB != nil {
+			closeFn = dbHandleNoBoundDB.Close
+		}
+
+		return nil, nil, opts.Database, closeFn, err
 	}
 
 	// post connection binding without opening the database, store database name for usage


### PR DESCRIPTION
This change:
- updates dependencies
- closes row results returned from abandoned DB checking (prior behavior would GC implicitly on function return)
- avoids case of panic on Connect() error when sql.Open() returns a nil db handle (unexpected as connectivity is not checked until used)
- improves documentation